### PR TITLE
Enable route logging middleware

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->append(App\Http\Middleware\RouteLogger::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/config/logging.php
+++ b/config/logging.php
@@ -73,6 +73,14 @@ return [
             'replace_placeholders' => true,
         ],
 
+        'route' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/route.log'),
+            'level' => 'info',
+            'days' => env('LOG_DAILY_DAYS', 14),
+            'replace_placeholders' => true,
+        ],
+
         'slack' => [
             'driver' => 'slack',
             'url' => env('LOG_SLACK_WEBHOOK_URL'),


### PR DESCRIPTION
## Summary
- add a daily log channel for routes
- enable RouteLogger middleware globally

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591a3248ac832f8406c0d9529ac45a