### PR TITLE
Implement API version prefix

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -4,7 +4,9 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\ExampleApiController;
 
-Route::post('/login', [AuthController::class, 'login']);
-Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);
-Route::get('/example', [ExampleApiController::class, 'index']);
+Route::prefix('v1')->group(function () {
+    Route::post('/login', [AuthController::class, 'login']);
+    Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);
+    Route::get('/example', [ExampleApiController::class, 'index']);
+});
 


### PR DESCRIPTION
## Summary
- group API routes under a `v1` prefix

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f76523ec832f83a4829dcab2d80d