### PR TITLE
Handle not found errors with JSON

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Exceptions;
+
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
+
+class Handler extends ExceptionHandler
+{
+    /**
+     * A list of exception types with their corresponding custom log levels.
+     *
+     * @var array<class-string<Throwable>, \Psr\Log\LogLevel::*>
+     */
+    protected $levels = [
+        //
+    ];
+
+    /**
+     * A list of the exception types that are not reported.
+     *
+     * @var array<int, class-string<Throwable>>
+     */
+    protected $dontReport = [
+        //
+    ];
+
+    /**
+     * A list of the inputs that are never flashed to the session on validation exceptions.
+     *
+     * @var array<int, string>
+     */
+    protected $dontFlash = [
+        'current_password',
+        'password',
+        'password_confirmation',
+    ];
+
+    /**
+     * Register the exception handling callbacks for the application.
+     */
+    public function register(): void
+    {
+        $this->reportable(function (Throwable $e) {
+            //
+        });
+    }
+
+    public function render($request, Throwable $e)
+    {
+        if ($e instanceof ModelNotFoundException || $e instanceof NotFoundHttpException) {
+            if ($request->expectsJson()) {
+                return response()->json([
+                    'meta' => [
+                        'code' => 404,
+                        'message' => 'Not Found',
+                    ],
+                    'result' => null,
+                ], 404);
+            }
+        }
+
+        return parent::render($request, $e);
+    }
+}

--- a/tests/Feature/NotFoundApiTest.php
+++ b/tests/Feature/NotFoundApiTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class NotFoundApiTest extends TestCase
+{
+    public function test_not_found_returns_json(): void
+    {
+        $response = $this->getJson('/api/unknown-endpoint');
+
+        $response->assertStatus(404)
+            ->assertExactJson([
+                'meta' => [
+                    'code' => 404,
+                    'message' => 'Not Found',
+                ],
+                'result' => null,
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a custom exception handler
- add a feature test for JSON 404 response

## Testing
- `composer install --no-interaction --no-progress` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6859fb9aadec832f9472c712fbc9d6c5