### PR TITLE
Handle not found errors with JSON

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,9 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -15,5 +18,17 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->append(App\Http\Middleware\RouteLogger::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
+        $exceptions->renderable(function (Throwable $e, $request) {
+            if ($e instanceof ModelNotFoundException || $e instanceof NotFoundHttpException) {
+                if ($request->expectsJson() || $request->is('api/*')) {
+                    return response()->json([
+                        'meta' => [
+                            'code' => 404,
+                            'message' => 'Not Found',
+                        ],
+                        'result' => null,
+                    ], 404);
+                }
+            }
+        });
     })->create();

--- a/tests/Feature/NotFoundApiTest.php
+++ b/tests/Feature/NotFoundApiTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class NotFoundApiTest extends TestCase
+{
+    public function test_not_found_returns_json(): void
+    {
+        $response = $this->get('/api/unknown-endpoint');
+
+        $response->assertStatus(404)
+            ->assertExactJson([
+                'meta' => [
+                    'code' => 404,
+                    'message' => 'Not Found',
+                ],
+                'result' => null,
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- return JSON for missing API routes even when the client doesn't set an Accept header
- test plain request to unknown API endpoint returns structured JSON

## Testing
- `composer install --no-interaction --no-progress` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: no such file or directory)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6859fb9aadec832f9472c712fbc9d6c5