### PR TITLE
Ensure API always returns JSON

### DIFF
--- a/app/Http/Middleware/ForceJsonResponse.php
+++ b/app/Http/Middleware/ForceJsonResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class ForceJsonResponse
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $request->headers->set('Accept', 'application/json');
+
+        $response = $next($request);
+        $response->headers->set('Content-Type', 'application/json');
+
+        return $response;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,6 +12,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
+        $middleware->append(App\Http\Middleware\ForceJsonResponse::class);
         $middleware->append(App\Http\Middleware\RouteLogger::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/tests/Feature/AuthApiTest.php
+++ b/tests/Feature/AuthApiTest.php
@@ -17,7 +17,7 @@ class AuthApiTest extends TestCase
             'password' => bcrypt('secret'),
         ]);
 
-        $response = $this->postJson('/api/login', [
+        $response = $this->postJson('/api/v1/login', [
             'email' => 'user@example.com',
             'password' => 'secret',
         ]);
@@ -32,7 +32,7 @@ class AuthApiTest extends TestCase
 
         $logout = $this->withHeaders([
             'Authorization' => 'Bearer ' . $token,
-        ])->postJson('/api/logout');
+        ])->postJson('/api/v1/logout');
 
         $logout->assertStatus(200)
             ->assertJsonPath('meta.message', 'Logged out');

--- a/tests/Feature/ExampleApiTest.php
+++ b/tests/Feature/ExampleApiTest.php
@@ -8,7 +8,7 @@ class ExampleApiTest extends TestCase
 {
     public function test_example_endpoint_returns_template(): void
     {
-        $response = $this->getJson('/api/example');
+        $response = $this->getJson('/api/v1/example');
 
         $response->assertStatus(200)
             ->assertJsonStructure([

--- a/tests/Feature/NotFoundApiTest.php
+++ b/tests/Feature/NotFoundApiTest.php
@@ -8,7 +8,7 @@ class NotFoundApiTest extends TestCase
 {
     public function test_not_found_returns_json(): void
     {
-        $response = $this->getJson('/api/unknown-endpoint');
+        $response = $this->getJson('/api/v1/unknown-endpoint');
 
         $response->assertStatus(404)
             ->assertExactJson([


### PR DESCRIPTION
## Summary
- create `ForceJsonResponse` middleware to set `Accept` and `Content-Type` headers
- register the new middleware globally
- update API feature tests to use the `/v1` prefix

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*
- `php artisan test --testsuite Feature` *(fails: php: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ff728c28832fa328c89bed94f850