### PR TITLE
Add registration API

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -5,9 +5,31 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
 
 class AuthController extends Controller
 {
+    public function register(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255', 'unique:users,email'],
+            'password' => ['required', 'confirmed'],
+        ]);
+
+        $user = User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => Hash::make($data['password']),
+            'status' => 'active',
+        ]);
+
+        $token = $user->createToken('api-token')->plainTextToken;
+
+        return $this->response(['token' => $token], 'Register successful', 201);
+    }
+
     public function login(Request $request)
     {
         $credentials = $request->validate([

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'status',
     ];
 
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -28,6 +28,7 @@ class UserFactory extends Factory
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'status' => 'active',
             'remember_token' => Str::random(10),
         ];
     }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->string('status')->default('active');
             $table->rememberToken();
             $table->timestamps();
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\ExampleApiController;
 
 Route::prefix('v1')->group(function () {
+    Route::post('/register', [AuthController::class, 'register']);
     Route::post('/login', [AuthController::class, 'login']);
     Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);
     Route::get('/example', [ExampleApiController::class, 'index']);

--- a/tests/Feature/RegisterApiTest.php
+++ b/tests/Feature/RegisterApiTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RegisterApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_register_and_receive_token(): void
+    {
+        $response = $this->postJson('/api/v1/register', [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'password' => 'secret',
+            'password_confirmation' => 'secret',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'meta' => ['code', 'message'],
+                'result' => ['token'],
+            ]);
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'john@example.com',
+            'status' => 'active',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add /api/v1/register route
- implement register endpoint in AuthController
- test user registration
- add status column to users table
- include status in User model and factory
- set default user status on registration

## Testing
- `composer test` *(fails: composer command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0240749c832f8a1e581b77d26d3f