### PR TITLE
Add user roles and listing API

### DIFF
--- a/app/Http/Controllers/Api/UserApiController.php
+++ b/app/Http/Controllers/Api/UserApiController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class UserApiController extends Controller
+{
+    public function index(Request $request)
+    {
+        $email = $request->query('email');
+        $perPage = $request->query('per_page', 15);
+
+        $query = User::with('role');
+        if ($email) {
+            $query->where('email', 'like', "%$email%");
+        }
+
+        $users = $query->paginate((int) $perPage);
+        $array = $this->camelKeys($users->toArray());
+
+        return $this->response($array, 'OK');
+    }
+
+    private function camelKeys(array $data): array
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            $key = Str::camel($key);
+            if (is_array($value)) {
+                $value = $this->camelKeys($value);
+            }
+            $result[$key] = $value;
+        }
+        return $result;
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Role extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Models\Role;
 
 class User extends Authenticatable
 {
@@ -22,6 +23,7 @@ class User extends Authenticatable
         'email',
         'password',
         'status',
+        'role_id',
     ];
 
     /**
@@ -45,5 +47,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function role()
+    {
+        return $this->belongsTo(Role::class);
     }
 }

--- a/database/factories/RoleFactory.php
+++ b/database/factories/RoleFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Role>
+ */
+class RoleFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->word(),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Role;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
@@ -29,6 +30,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'status' => true, // true for active, false for inactive
+            'role_id' => Role::factory(),
             'remember_token' => Str::random(10),
         ];
     }

--- a/database/migrations/2025_06_23_085537_create_roles_table.php
+++ b/database/migrations/2025_06_23_085537_create_roles_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/database/migrations/2025_06_23_085538_add_role_id_to_users_table.php
+++ b/database/migrations/2025_06_23_085538_add_role_id_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('role_id')->after('id')->constrained('roles');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('role_id');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,8 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use Database\Seeders\RoleSeeder;
+use Database\Seeders\UserSeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -14,6 +16,11 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         // User::factory(10)->create();
+
+        $this->call([
+            RoleSeeder::class,
+            UserSeeder::class,
+        ]);
 
         User::factory()->create([
             'name' => 'Test User',

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Role;
+
+class RoleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $roles = [
+            'Kantor Wilayah',
+            'Kantor Kabupaten/Kota',
+            'Madrasah',
+        ];
+
+        foreach ($roles as $role) {
+            Role::firstOrCreate(['name' => $role]);
+        }
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\User;
+use App\Models\Role;
+use Illuminate\Support\Facades\Hash;
+
+class UserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $role = Role::where('name', 'Kantor Wilayah')->first();
+        if (!$role) {
+            $role = Role::create(['name' => 'Kantor Wilayah']);
+        }
+
+        User::firstOrCreate(
+            ['email' => 'lukmanhidayah01@gmail.com'],
+            [
+                'name' => 'Lukman Hidayah',
+                'password' => Hash::make('password'),
+                'status' => true,
+                'role_id' => $role->id,
+            ]
+        );
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,11 +3,13 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\ExampleApiController;
+use App\Http\Controllers\Api\UserApiController;
 
 Route::prefix('v1')->group(function () {
     Route::post('/register', [AuthController::class, 'register']);
     Route::post('/login', [AuthController::class, 'login']);
     Route::middleware('auth:sanctum')->post('/logout', [AuthController::class, 'logout']);
     Route::get('/example', [ExampleApiController::class, 'index']);
+    Route::get('/users', [UserApiController::class, 'index']);
 });
 

--- a/tests/Feature/UserApiTest.php
+++ b/tests/Feature/UserApiTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_list_users_with_pagination(): void
+    {
+        User::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/v1/users');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'meta' => ['code', 'message'],
+                'result' => [
+                    'currentPage',
+                    'data' => [
+                        ['id', 'name', 'email', 'roleId']
+                    ],
+                ],
+            ]);
+    }
+
+    public function test_can_filter_users_by_email(): void
+    {
+        $user = User::factory()->create(['email' => 'specific@example.com']);
+        User::factory()->count(2)->create();
+
+        $response = $this->getJson('/api/v1/users?email=specific@example.com');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('result.data.0.email', 'specific@example.com');
+    }
+}


### PR DESCRIPTION
## Summary
- create `roles` table and link users to roles
- add seeders for roles and a default Kantor Wilayah user
- add factories for roles and update user factory
- implement user listing API with pagination and email filter
- provide feature test for the new endpoint

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a09afb85c832fa7090f9781e0d716