### PR TITLE
Add menu API with role-based routes

### DIFF
--- a/app/Http/Controllers/Api/AuthController.php
+++ b/app/Http/Controllers/Api/AuthController.php
@@ -42,9 +42,13 @@ class AuthController extends Controller
             return $this->response(null, 'Unauthorized', 401);
         }
 
-        $token = $request->user()->createToken('api-token')->plainTextToken;
+        $user = $request->user();
+        $token = $user->createToken('api-token')->plainTextToken;
 
-        return $this->response(['token' => $token], 'Login successful');
+        return $this->response([
+            'token' => $token,
+            'role'  => optional($user->role)->name,
+        ], 'Login successful');
     }
 
     public function logout(Request $request)

--- a/app/Http/Controllers/Api/MenuApiController.php
+++ b/app/Http/Controllers/Api/MenuApiController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Menu;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class MenuApiController extends Controller
+{
+    public function index(Request $request)
+    {
+        $user = $request->user();
+        $menus = Menu::where('role_id', $user->role_id)->get();
+        $array = $this->camelKeys($menus->toArray());
+
+        return $this->response($array, 'OK');
+    }
+
+    private function camelKeys(array $data): array
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            $key = Str::camel($key);
+            if (is_array($value)) {
+                $value = $this->camelKeys($value);
+            }
+            $result[$key] = $value;
+        }
+        return $result;
+    }
+}

--- a/app/Models/Menu.php
+++ b/app/Models/Menu.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Menu extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'role_id',
+        'name',
+        'url',
+    ];
+
+    public function role()
+    {
+        return $this->belongsTo(Role::class);
+    }
+}

--- a/database/factories/MenuFactory.php
+++ b/database/factories/MenuFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Role;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Menu>
+ */
+class MenuFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'role_id' => Role::factory(),
+            'name' => $this->faker->word(),
+            'url' => '/' . $this->faker->slug(),
+        ];
+    }
+}

--- a/database/migrations/2025_06_23_085539_create_menus_table.php
+++ b/database/migrations/2025_06_23_085539_create_menus_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('menus', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('role_id')->constrained('roles');
+            $table->string('name');
+            $table->string('url');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('menus');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             RoleSeeder::class,
             UserSeeder::class,
+            MenuSeeder::class,
         ]);
     }
 }

--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Menu;
+use App\Models\Role;
+
+class MenuSeeder extends Seeder
+{
+    public function run(): void
+    {
+        foreach (Role::all() as $role) {
+            Menu::firstOrCreate(
+                ['role_id' => $role->id, 'name' => 'Home'],
+                ['url' => '/home']
+            );
+            Menu::firstOrCreate(
+                ['role_id' => $role->id, 'name' => 'Profile'],
+                ['url' => '/profile']
+            );
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\ExampleApiController;
 use App\Http\Controllers\Api\UserApiController;
+use App\Http\Controllers\Api\MenuApiController;
 
 Route::prefix('v1')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -12,6 +13,7 @@ Route::prefix('v1')->group(function () {
     Route::middleware('auth:sanctum')->group(function () {
         Route::post('/logout', [AuthController::class, 'logout']);
         Route::get('/users', [UserApiController::class, 'index']);
-        Route::post('/register', [AuthController::class, 'register']);
+        Route::post('/users', [AuthController::class, 'register']);
+        Route::get('/menus', [MenuApiController::class, 'index']);
     });
 });

--- a/tests/Feature/AuthApiTest.php
+++ b/tests/Feature/AuthApiTest.php
@@ -25,7 +25,7 @@ class AuthApiTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonStructure([
                 'meta' => ['code', 'message'],
-                'result' => ['token'],
+                'result' => ['token', 'role'],
             ]);
 
         $token = $response->json('result.token');

--- a/tests/Feature/MenuApiTest.php
+++ b/tests/Feature/MenuApiTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Menu;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MenuApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_lists_menus_for_authenticated_user(): void
+    {
+        $user = User::factory()->create(['password' => bcrypt('secret')]);
+        Menu::factory()->count(2)->create(['role_id' => $user->role_id]);
+
+        $login = $this->postJson('/api/v1/login', [
+            'email' => $user->email,
+            'password' => 'secret',
+        ]);
+
+        $token = $login->json('result.token');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->getJson('/api/v1/menus');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'meta' => ['code', 'message'],
+                'result' => [
+                    ['id', 'roleId', 'name', 'url']
+                ],
+            ])
+            ->assertJsonCount(2, 'result');
+    }
+}

--- a/tests/Feature/RegisterApiTest.php
+++ b/tests/Feature/RegisterApiTest.php
@@ -11,7 +11,7 @@ class RegisterApiTest extends TestCase
 
     public function test_user_can_register_and_receive_token(): void
     {
-        $response = $this->postJson('/api/v1/register', [
+        $response = $this->postJson('/api/v1/users', [
             'name' => 'John Doe',
             'email' => 'john@example.com',
             'password' => 'secret',


### PR DESCRIPTION
## Summary
- change register URL to `/users`
- show user role on login response
- create `menus` table and seeder
- add menu model, factory, controller, and route
- provide menu API tests and adapt existing tests

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a11451448832f915b42f55fdb8bc9