### PR TITLE
Implement menu-role pivot and new APIs

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,6 +3,7 @@
 namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
@@ -63,5 +64,20 @@ class Handler extends ExceptionHandler
         }
 
         return parent::render($request, $e);
+    }
+
+    protected function unauthenticated($request, AuthenticationException $exception)
+    {
+        if ($request->expectsJson()) {
+            return response()->json([
+                'meta' => [
+                    'code' => 401,
+                    'message' => 'Unauthorized',
+                ],
+                'result' => null,
+            ], 401);
+        }
+
+        return parent::unauthenticated($request, $exception);
     }
 }

--- a/app/Http/Controllers/Api/InsightApiController.php
+++ b/app/Http/Controllers/Api/InsightApiController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Str;
+
+class InsightApiController extends Controller
+{
+    public function index()
+    {
+        $data = [
+            ['title' => 'Total Kebutuhan', 'value' => '0'],
+            ['title' => 'Jumlah Kebutuhan', 'value' => '0'],
+            ['title' => 'Jumlah Kelebihan', 'value' => '0'],
+            ['title' => 'Jumlah Kekurangan', 'value' => '0'],
+        ];
+
+        return $this->response($this->camelKeys($data), 'Success');
+    }
+
+    private function camelKeys(array $data): array
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            $key = Str::camel($key);
+            if (is_array($value)) {
+                $value = $this->camelKeys($value);
+            }
+            $result[$key] = $value;
+        }
+        return $result;
+    }
+}

--- a/app/Http/Controllers/Api/MenuApiController.php
+++ b/app/Http/Controllers/Api/MenuApiController.php
@@ -11,11 +11,42 @@ class MenuApiController extends Controller
 {
     public function index(Request $request)
     {
-        $user = $request->user();
-        $menus = Menu::where('role_id', $user->role_id)->get();
+        $perPage = $request->query('per_page', 15);
+        $menus = Menu::with('roles')->paginate((int) $perPage);
         $array = $this->camelKeys($menus->toArray());
 
         return $this->response($array, 'OK');
+    }
+
+    public function show(int $id)
+    {
+        $menu = Menu::with('roles')->findOrFail($id);
+        $array = $this->camelKeys($menu->toArray());
+
+        return $this->response($array, 'OK');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string'],
+            'url' => ['required', 'string'],
+            'role_ids' => ['array'],
+        ]);
+
+        $menu = Menu::create([
+            'name' => $data['name'],
+            'url' => $data['url'],
+        ]);
+
+        if (!empty($data['role_ids'])) {
+            $menu->roles()->sync($data['role_ids']);
+        }
+
+        $menu->load('roles');
+        $array = $this->camelKeys($menu->toArray());
+
+        return $this->response($array, 'Created', 201);
     }
 
     private function camelKeys(array $data): array

--- a/app/Http/Controllers/Api/RoleApiController.php
+++ b/app/Http/Controllers/Api/RoleApiController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Role;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class RoleApiController extends Controller
+{
+    public function index(Request $request)
+    {
+        $perPage = $request->query('per_page', 15);
+        $roles = Role::paginate((int) $perPage);
+        $array = $this->camelKeys($roles->toArray());
+
+        return $this->response($array, 'OK');
+    }
+
+    public function show(int $id)
+    {
+        $role = Role::with('menus')->findOrFail($id);
+        $array = $this->camelKeys($role->toArray());
+
+        return $this->response($array, 'OK');
+    }
+
+    private function camelKeys(array $data): array
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            $key = Str::camel($key);
+            if (is_array($value)) {
+                $value = $this->camelKeys($value);
+            }
+            $result[$key] = $value;
+        }
+        return $result;
+    }
+}

--- a/app/Http/Controllers/Api/UserApiController.php
+++ b/app/Http/Controllers/Api/UserApiController.php
@@ -35,6 +35,14 @@ class UserApiController extends Controller
         return $this->response($data, 'OK');
     }
 
+    public function show(int $id)
+    {
+        $user = User::with('role')->findOrFail($id);
+        $data = $this->camelKeys($user->toArray());
+
+        return $this->response($data, 'OK');
+    }
+
     private function camelKeys(array $data): array
     {
         $result = [];

--- a/app/Models/Menu.php
+++ b/app/Models/Menu.php
@@ -10,13 +10,12 @@ class Menu extends Model
     use HasFactory;
 
     protected $fillable = [
-        'role_id',
         'name',
         'url',
     ];
 
-    public function role()
+    public function roles()
     {
-        return $this->belongsTo(Role::class);
+        return $this->belongsToMany(Role::class);
     }
 }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -10,4 +10,9 @@ class Role extends Model
     use HasFactory;
 
     protected $fillable = ['name'];
+
+    public function menus()
+    {
+        return $this->belongsToMany(Menu::class);
+    }
 }

--- a/database/factories/MenuFactory.php
+++ b/database/factories/MenuFactory.php
@@ -13,7 +13,6 @@ class MenuFactory extends Factory
     public function definition(): array
     {
         return [
-            'role_id' => Role::factory(),
             'name' => $this->faker->word(),
             'url' => '/' . $this->faker->slug(),
         ];

--- a/database/migrations/2025_06_24_000000_create_menu_role_table.php
+++ b/database/migrations/2025_06_24_000000_create_menu_role_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('menu_role', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('menu_id')->constrained('menus');
+            $table->foreignId('role_id')->constrained('roles');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('menu_role');
+    }
+};

--- a/database/migrations/2025_06_24_000001_drop_role_id_from_menus_table.php
+++ b/database/migrations/2025_06_24_000001_drop_role_id_from_menus_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            if (Schema::hasColumn('menus', 'role_id')) {
+                $table->dropConstrainedForeignId('role_id');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            if (!Schema::hasColumn('menus', 'role_id')) {
+                $table->foreignId('role_id')->nullable()->constrained('roles');
+            }
+        });
+    }
+};

--- a/database/seeders/MenuSeeder.php
+++ b/database/seeders/MenuSeeder.php
@@ -10,15 +10,11 @@ class MenuSeeder extends Seeder
 {
     public function run(): void
     {
+        $home = Menu::firstOrCreate(['name' => 'Home'], ['url' => '/home']);
+        $profile = Menu::firstOrCreate(['name' => 'Profile'], ['url' => '/profile']);
+
         foreach (Role::all() as $role) {
-            Menu::firstOrCreate(
-                ['role_id' => $role->id, 'name' => 'Home'],
-                ['url' => '/home']
-            );
-            Menu::firstOrCreate(
-                ['role_id' => $role->id, 'name' => 'Profile'],
-                ['url' => '/profile']
-            );
+            $role->menus()->syncWithoutDetaching([$home->id, $profile->id]);
         }
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,8 @@ use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\ExampleApiController;
 use App\Http\Controllers\Api\UserApiController;
 use App\Http\Controllers\Api\MenuApiController;
+use App\Http\Controllers\Api\RoleApiController;
+use App\Http\Controllers\Api\InsightApiController;
 
 Route::prefix('v1')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -14,6 +16,15 @@ Route::prefix('v1')->group(function () {
         Route::get('/users', [UserApiController::class, 'index']);
         Route::post('/users', [AuthController::class, 'register']);
         Route::get('/profile', [UserApiController::class, 'profile']);
+        Route::get('/users/{id}', [UserApiController::class, 'show']);
+
         Route::get('/menus', [MenuApiController::class, 'index']);
+        Route::post('/menus', [MenuApiController::class, 'store']);
+        Route::get('/menus/{id}', [MenuApiController::class, 'show']);
+
+        Route::get('/roles', [RoleApiController::class, 'index']);
+        Route::get('/roles/{id}', [RoleApiController::class, 'show']);
+
+        Route::get('/insights', [InsightApiController::class, 'index']);
     });
 });

--- a/tests/Feature/InsightApiTest.php
+++ b/tests/Feature/InsightApiTest.php
@@ -3,21 +3,16 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use App\Models\Menu;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-class MenuApiTest extends TestCase
+class InsightApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_lists_menus_with_pagination(): void
+    public function test_insight_endpoint_returns_data(): void
     {
         $user = User::factory()->create(['password' => bcrypt('secret')]);
-        $menus = Menu::factory()->count(3)->create();
-        foreach ($menus as $menu) {
-            $menu->roles()->attach($user->role_id);
-        }
 
         $login = $this->postJson('/api/v1/login', [
             'email' => $user->email,
@@ -28,14 +23,13 @@ class MenuApiTest extends TestCase
 
         $response = $this->withHeaders([
             'Authorization' => 'Bearer ' . $token,
-        ])->getJson('/api/v1/menus');
+        ])->getJson('/api/v1/insights');
 
         $response->assertStatus(200)
             ->assertJsonStructure([
                 'meta' => ['code', 'message'],
                 'result' => [
-                    'currentPage',
-                    'data',
+                    ['title', 'value'],
                 ],
             ]);
     }

--- a/tests/Feature/RoleApiTest.php
+++ b/tests/Feature/RoleApiTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RoleApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_lists_roles_with_pagination(): void
+    {
+        Role::factory()->count(3)->create();
+
+        $response = $this->actingAs(User::factory()->create())
+            ->getJson('/api/v1/roles');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'meta' => ['code', 'message'],
+                'result' => ['currentPage', 'data'],
+            ]);
+    }
+}

--- a/tests/Feature/UserDetailApiTest.php
+++ b/tests/Feature/UserDetailApiTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserDetailApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_get_user_detail(): void
+    {
+        $user = User::factory()->create();
+        $auth = User::factory()->create(['password' => bcrypt('secret')]);
+
+        $login = $this->postJson('/api/v1/login', [
+            'email' => $auth->email,
+            'password' => 'secret',
+        ]);
+
+        $token = $login->json('result.token');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->getJson('/api/v1/users/' . $user->id);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('result.id', $user->id);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure 401 responses use JSON template
- change menus & roles to many-to-many relationship
- add migrations for `menu_role` pivot table
- update menu seeder
- add controllers for menus, roles, and insights with pagination
- expose user detail endpoint
- update API routes
- adjust factories and tests

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a187b4dfc832fa2337f2123c91cb5