### PR TITLE
Add madrasah module and other improvements

### DIFF
--- a/app/Http/Controllers/Api/MadrasahApiController.php
+++ b/app/Http/Controllers/Api/MadrasahApiController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Madrasah;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class MadrasahApiController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = $request->query('page', 1);
+        $pageSize = $request->query('pageSize', 10);
+        $madrasahs = Madrasah::orderBy('id', 'asc')
+            ->paginate((int) $pageSize, ['*'], 'page', (int) $page);
+
+        $array = $this->camelKeys($madrasahs->toArray());
+        $customPagination = [
+            'currentPage' => $madrasahs->currentPage(),
+            'pageSize' => $madrasahs->perPage(),
+            'total' => $madrasahs->total(),
+            'data' => $array['data'] ?? [],
+        ];
+
+        return $this->response($customPagination, 'Retrieved successfully');
+    }
+
+    public function show(int $id)
+    {
+        $madrasah = Madrasah::findOrFail($id);
+        $array = $this->camelKeys($madrasah->toArray());
+
+        return $this->response($array, 'Retrieved successfully');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'nsm' => ['required', 'string', 'unique:madrasahs,nsm'],
+            'name' => ['required', 'string'],
+            'address' => ['required', 'string'],
+            'madrasah_level_id' => ['required', 'integer', 'exists:madrasah_levels,id'],
+            'regency_id' => ['required', 'integer'],
+            'district_id' => ['required', 'integer'],
+            'village_id' => ['required', 'integer'],
+            'kepala_madrasah' => ['string'],
+            'wakakur_name' => ['string'],
+            'wakakur_phone' => ['string'],
+        ]);
+
+        $madrasah = Madrasah::create($data);
+
+        $array = $this->camelKeys($madrasah->toArray());
+
+        return $this->response($array, 'Created', 201);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $madrasah = Madrasah::findOrFail($id);
+        $data = $request->validate([
+            'nsm' => ['string', 'unique:madrasahs,nsm,' . $id],
+            'name' => ['string'],
+            'address' => ['string'],
+            'madrasah_level_id' => ['integer', 'exists:madrasah_levels,id'],
+            'regency_id' => ['integer'],
+            'district_id' => ['integer'],
+            'village_id' => ['integer'],
+            'kepala_madrasah' => ['string'],
+            'wakakur_name' => ['string'],
+            'wakakur_phone' => ['string'],
+        ]);
+
+        $madrasah->update($data);
+
+        $array = $this->camelKeys($madrasah->toArray());
+
+        return $this->response($array, 'Updated');
+    }
+
+    public function destroy(int $id)
+    {
+        $madrasah = Madrasah::findOrFail($id);
+        $madrasah->delete();
+
+        return $this->response(null, 'Deleted');
+    }
+
+    private function camelKeys(array $data): array
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            $key = Str::camel($key);
+            if (is_array($value)) {
+                $value = $this->camelKeys($value);
+            }
+            $result[$key] = $value;
+        }
+        return $result;
+    }
+}

--- a/app/Http/Controllers/Api/MenuApiController.php
+++ b/app/Http/Controllers/Api/MenuApiController.php
@@ -41,12 +41,14 @@ class MenuApiController extends Controller
         $data = $request->validate([
             'name' => ['required', 'string'],
             'url' => ['required', 'string'],
+            'icon_type' => ['required', 'string'],
             'role_ids' => ['array'],
         ]);
 
         $menu = Menu::create([
             'name' => $data['name'],
             'url' => $data['url'],
+            'icon_type' => $data['icon_type'],
         ]);
 
         if (!empty($data['role_ids'])) {

--- a/app/Http/Controllers/Api/RoleApiController.php
+++ b/app/Http/Controllers/Api/RoleApiController.php
@@ -34,6 +34,19 @@ class RoleApiController extends Controller
         return $this->response($array, 'Retrieved successfully');
     }
 
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'unique:roles,name'],
+        ]);
+
+        $role = Role::create(['name' => $data['name']]);
+
+        $array = $this->camelKeys($role->toArray());
+
+        return $this->response($array, 'Created', 201);
+    }
+
     private function camelKeys(array $data): array
     {
         $result = [];

--- a/app/Models/AcademicYear.php
+++ b/app/Models/AcademicYear.php
@@ -5,18 +5,15 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class Menu extends Model
+class AcademicYear extends Model
 {
     use HasFactory;
 
     protected $fillable = [
-        'name',
-        'url',
-        'icon_type',
+        'code',
+        'start_date',
+        'end_date',
+        'created_by',
+        'updated_by',
     ];
-
-    public function roles()
-    {
-        return $this->belongsToMany(Role::class);
-    }
 }

--- a/app/Models/CalculationMethod.php
+++ b/app/Models/CalculationMethod.php
@@ -5,18 +5,14 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class Menu extends Model
+class CalculationMethod extends Model
 {
     use HasFactory;
 
     protected $fillable = [
         'name',
-        'url',
-        'icon_type',
+        'divisor_value',
+        'created_by',
+        'updated_by',
     ];
-
-    public function roles()
-    {
-        return $this->belongsToMany(Role::class);
-    }
 }

--- a/app/Models/ClassLevel.php
+++ b/app/Models/ClassLevel.php
@@ -5,18 +5,15 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class Menu extends Model
+class ClassLevel extends Model
 {
     use HasFactory;
 
     protected $fillable = [
         'name',
-        'url',
-        'icon_type',
+        'description',
+        'madrasah_level_id',
+        'created_by',
+        'updated_by',
     ];
-
-    public function roles()
-    {
-        return $this->belongsToMany(Role::class);
-    }
 }

--- a/app/Models/Madrasah.php
+++ b/app/Models/Madrasah.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Madrasah extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'nsm',
+        'name',
+        'address',
+        'madrasah_level_id',
+        'regency_id',
+        'district_id',
+        'village_id',
+        'kepala_madrasah',
+        'wakakur_name',
+        'wakakur_phone',
+        'created_by',
+        'updated_by',
+    ];
+}

--- a/app/Models/MadrasahLevel.php
+++ b/app/Models/MadrasahLevel.php
@@ -5,18 +5,14 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class Menu extends Model
+class MadrasahLevel extends Model
 {
     use HasFactory;
 
     protected $fillable = [
         'name',
-        'url',
-        'icon_type',
+        'description',
+        'created_by',
+        'updated_by',
     ];
-
-    public function roles()
-    {
-        return $this->belongsToMany(Role::class);
-    }
 }

--- a/app/Models/Subject.php
+++ b/app/Models/Subject.php
@@ -5,18 +5,13 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class Menu extends Model
+class Subject extends Model
 {
     use HasFactory;
 
     protected $fillable = [
         'name',
-        'url',
-        'icon_type',
+        'created_by',
+        'updated_by',
     ];
-
-    public function roles()
-    {
-        return $this->belongsToMany(Role::class);
-    }
 }

--- a/app/Models/TeacherNeed.php
+++ b/app/Models/TeacherNeed.php
@@ -5,18 +5,16 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class Menu extends Model
+class TeacherNeed extends Model
 {
     use HasFactory;
 
     protected $fillable = [
-        'name',
-        'url',
-        'icon_type',
+        'madrasah_id',
+        'subject_id',
+        'academic_year_id',
+        'calculation_method_id',
+        'created_by',
+        'updated_by',
     ];
-
-    public function roles()
-    {
-        return $this->belongsToMany(Role::class);
-    }
 }

--- a/app/Models/TeacherNeedCalculation.php
+++ b/app/Models/TeacherNeedCalculation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TeacherNeedCalculation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'teacher_need_id',
+        'calculation_date',
+        'calculation_method_id',
+        'teacher_existing_count',
+        'result',
+        'notes',
+        'created_by',
+        'updated_by',
+    ];
+}

--- a/app/Models/TeacherNeedDetail.php
+++ b/app/Models/TeacherNeedDetail.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TeacherNeedDetail extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'teacher_need_id',
+        'class_level_id',
+        'rombel_count',
+        'student_count',
+        'allocation_per_week',
+        'total_hours',
+        'created_by',
+        'updated_by',
+    ];
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,6 +4,7 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Auth\AuthenticationException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 
@@ -19,7 +20,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->append(App\Http\Middleware\RouteLogger::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-          $exceptions->renderable(function (Throwable $e, $request) {
+        $exceptions->renderable(function (Throwable $e, $request) {
             if ($e instanceof ModelNotFoundException || $e instanceof NotFoundHttpException) {
                 if ($request->expectsJson() || $request->is('api/*')) {
                     return response()->json([
@@ -29,6 +30,18 @@ return Application::configure(basePath: dirname(__DIR__))
                         ],
                         'result' => null,
                     ], 404);
+                }
+            }
+
+            if ($e instanceof AuthenticationException) {
+                if ($request->expectsJson() || $request->is('api/*')) {
+                    return response()->json([
+                        'meta' => [
+                            'code' => 401,
+                            'message' => 'Unauthorized',
+                        ],
+                        'result' => null,
+                    ], 401);
                 }
             }
         });

--- a/database/factories/MadrasahFactory.php
+++ b/database/factories/MadrasahFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Madrasah>
+ */
+class MadrasahFactory extends Factory
+{
+    protected $model = \App\Models\Madrasah::class;
+
+    public function definition(): array
+    {
+        return [
+            'nsm' => $this->faker->unique()->numerify('NSM####'),
+            'name' => $this->faker->company(),
+            'address' => $this->faker->address(),
+            'madrasah_level_id' => \App\Models\MadrasahLevel::factory(),
+            'regency_id' => 1,
+            'district_id' => 1,
+            'village_id' => 1,
+        ];
+    }
+}

--- a/database/factories/MadrasahLevelFactory.php
+++ b/database/factories/MadrasahLevelFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\MadrasahLevel>
+ */
+class MadrasahLevelFactory extends Factory
+{
+    protected $model = \App\Models\MadrasahLevel::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->word(),
+            'description' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/factories/MenuFactory.php
+++ b/database/factories/MenuFactory.php
@@ -15,6 +15,7 @@ class MenuFactory extends Factory
         return [
             'name' => $this->faker->word(),
             'url' => '/' . $this->faker->slug(),
+            'icon_type' => 'default',
         ];
     }
 }

--- a/database/migrations/2025_06_24_000001_add_icon_type_to_menus_table.php
+++ b/database/migrations/2025_06_24_000001_add_icon_type_to_menus_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            $table->string('icon_type')->after('url');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('menus', function (Blueprint $table) {
+            $table->dropColumn('icon_type');
+        });
+    }
+};

--- a/database/migrations/2025_06_24_100000_create_academic_years_table.php
+++ b/database/migrations/2025_06_24_100000_create_academic_years_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('academic_years', function (Blueprint $table) {
+            $table->id();
+            $table->string('code', 20)->unique();
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->timestamp('created_at')->default(now());
+            $table->string('created_by', 100)->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->string('updated_by', 100)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('academic_years');
+    }
+};

--- a/database/migrations/2025_06_24_100100_create_madrasah_levels_table.php
+++ b/database/migrations/2025_06_24_100100_create_madrasah_levels_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('madrasah_levels', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 50)->unique();
+            $table->text('description')->nullable();
+            $table->timestamp('created_at')->default(now());
+            $table->string('created_by', 100)->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->string('updated_by', 100)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('madrasah_levels');
+    }
+};

--- a/database/migrations/2025_06_24_100200_create_class_levels_table.php
+++ b/database/migrations/2025_06_24_100200_create_class_levels_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('class_levels', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 50)->unique();
+            $table->text('description')->nullable();
+            $table->foreignId('madrasah_level_id')->constrained('madrasah_levels');
+            $table->timestamp('created_at')->default(now());
+            $table->string('created_by', 100)->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->string('updated_by', 100)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('class_levels');
+    }
+};

--- a/database/migrations/2025_06_24_100300_create_madrasahs_table.php
+++ b/database/migrations/2025_06_24_100300_create_madrasahs_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('madrasahs', function (Blueprint $table) {
+            $table->id();
+            $table->string('nsm', 50)->unique();
+            $table->string('name', 255);
+            $table->string('address', 255);
+            $table->foreignId('madrasah_level_id')->constrained('madrasah_levels');
+            $table->unsignedBigInteger('regency_id');
+            $table->unsignedBigInteger('district_id');
+            $table->unsignedBigInteger('village_id');
+            $table->string('kepala_madrasah', 100)->nullable();
+            $table->string('wakakur_name', 100)->nullable();
+            $table->string('wakakur_phone', 20)->nullable();
+            $table->timestamp('created_at')->default(now());
+            $table->string('created_by', 100)->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->string('updated_by', 100)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('madrasahs');
+    }
+};

--- a/database/migrations/2025_06_24_100400_create_subjects_table.php
+++ b/database/migrations/2025_06_24_100400_create_subjects_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subjects', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100)->unique();
+            $table->timestamp('created_at')->default(now());
+            $table->string('created_by', 100)->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->string('updated_by', 100)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subjects');
+    }
+};

--- a/database/migrations/2025_06_24_100500_create_calculation_methods_table.php
+++ b/database/migrations/2025_06_24_100500_create_calculation_methods_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('calculation_methods', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 50)->unique();
+            $table->decimal('divisor_value', 10, 2);
+            $table->timestamp('created_at')->default(now());
+            $table->string('created_by', 100)->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->string('updated_by', 100)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('calculation_methods');
+    }
+};

--- a/database/migrations/2025_06_24_100600_create_teacher_needs_table.php
+++ b/database/migrations/2025_06_24_100600_create_teacher_needs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('teacher_needs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('madrasah_id')->constrained('madrasahs');
+            $table->foreignId('subject_id')->constrained('subjects');
+            $table->foreignId('academic_year_id')->constrained('academic_years');
+            $table->foreignId('calculation_method_id')->constrained('calculation_methods');
+            $table->timestamp('created_at')->default(now());
+            $table->string('created_by', 100)->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->string('updated_by', 100)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('teacher_needs');
+    }
+};

--- a/database/migrations/2025_06_24_100700_create_teacher_need_details_table.php
+++ b/database/migrations/2025_06_24_100700_create_teacher_need_details_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('teacher_need_details', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('teacher_need_id')->constrained('teacher_needs');
+            $table->foreignId('class_level_id')->constrained('class_levels');
+            $table->integer('rombel_count')->default(0);
+            $table->integer('student_count')->default(0);
+            $table->integer('allocation_per_week')->default(0);
+            $table->integer('total_hours')->default(0);
+            $table->timestamp('created_at')->default(now());
+            $table->string('created_by', 100)->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->string('updated_by', 100)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('teacher_need_details');
+    }
+};

--- a/database/migrations/2025_06_24_100800_create_teacher_need_calculations_table.php
+++ b/database/migrations/2025_06_24_100800_create_teacher_need_calculations_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('teacher_need_calculations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('teacher_need_id')->constrained('teacher_needs');
+            $table->timestamp('calculation_date')->default(now());
+            $table->foreignId('calculation_method_id')->constrained('calculation_methods');
+            $table->integer('teacher_existing_count')->default(0);
+            $table->decimal('result', 5, 2);
+            $table->text('notes')->nullable();
+            $table->timestamp('created_at')->default(now());
+            $table->string('created_by', 100)->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->string('updated_by', 100)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('teacher_need_calculations');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\UserApiController;
 use App\Http\Controllers\Api\MenuApiController;
 use App\Http\Controllers\Api\RoleApiController;
 use App\Http\Controllers\Api\InsightApiController;
+use App\Http\Controllers\Api\MadrasahApiController;
 
 Route::prefix('v1')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -25,8 +26,15 @@ Route::prefix('v1')->group(function () {
         Route::get('/menus/{id}', [MenuApiController::class, 'show']);
 
         Route::get('/roles', [RoleApiController::class, 'index']);
+        Route::post('/roles', [RoleApiController::class, 'store']);
         Route::get('/roles/{id}', [RoleApiController::class, 'show']);
 
         Route::get('/insights', [InsightApiController::class, 'index']);
+
+        Route::get('/madrasahs', [MadrasahApiController::class, 'index']);
+        Route::post('/madrasahs', [MadrasahApiController::class, 'store']);
+        Route::get('/madrasahs/{id}', [MadrasahApiController::class, 'show']);
+        Route::put('/madrasahs/{id}', [MadrasahApiController::class, 'update']);
+        Route::delete('/madrasahs/{id}', [MadrasahApiController::class, 'destroy']);
     });
 });

--- a/tests/Feature/MadrasahApiTest.php
+++ b/tests/Feature/MadrasahApiTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Madrasah;
+use App\Models\MadrasahLevel;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MadrasahApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crud_madrasah(): void
+    {
+        $level = MadrasahLevel::factory()->create();
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/v1/madrasahs', [
+                'nsm' => '1234',
+                'name' => 'Madrasah Test',
+                'address' => 'Address',
+                'madrasah_level_id' => $level->id,
+                'regency_id' => 1,
+                'district_id' => 1,
+                'village_id' => 1,
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('result.name', 'Madrasah Test');
+
+        $id = $response->json('result.id');
+
+        $update = $this->actingAs($user)
+            ->putJson('/api/v1/madrasahs/'.$id, [
+                'name' => 'Updated',
+            ]);
+
+        $update->assertStatus(200)
+            ->assertJsonPath('result.name', 'Updated');
+
+        $delete = $this->actingAs($user)
+            ->deleteJson('/api/v1/madrasahs/'.$id);
+
+        $delete->assertStatus(200)
+            ->assertJsonPath('meta.message', 'Deleted');
+    }
+}

--- a/tests/Feature/MenuApiTest.php
+++ b/tests/Feature/MenuApiTest.php
@@ -38,5 +38,7 @@ class MenuApiTest extends TestCase
                     'data',
                 ],
             ]);
+
+        $this->assertArrayHasKey('iconType', $response->json('result.data.0'));
     }
 }

--- a/tests/Feature/RoleApiTest.php
+++ b/tests/Feature/RoleApiTest.php
@@ -24,4 +24,19 @@ class RoleApiTest extends TestCase
                 'result' => ['currentPage', 'data'],
             ]);
     }
+
+    public function test_create_role(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/v1/roles', [
+                'name' => 'New Role',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('result.name', 'New Role');
+
+        $this->assertDatabaseHas('roles', ['name' => 'New Role']);
+    }
 }

--- a/tests/Feature/UnauthorizedApiTest.php
+++ b/tests/Feature/UnauthorizedApiTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class UnauthorizedApiTest extends TestCase
+{
+    public function test_unauthorized_returns_meta_structure(): void
+    {
+        $response = $this->getJson('/api/v1/menus');
+
+        $response->assertStatus(401)
+            ->assertExactJson([
+                'meta' => [
+                    'code' => 401,
+                    'message' => 'Unauthorized',
+                ],
+                'result' => null,
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- return meta structure for 401 responses
- support `icon_type` on menus
- allow creating roles through the API
- add madrasah CRUD endpoints and related tables
- extend test coverage for new behaviour

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685a4222f1f0832f9f8950050b08962a