### PR TITLE
Implement camelCase request handling

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,6 +5,9 @@ namespace App\Exceptions;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
 
@@ -77,5 +80,30 @@ class Handler extends ExceptionHandler
 
 
         return parent::render($request, $e);
+    }
+
+    protected function invalidJson($request, ValidationException $exception): JsonResponse
+    {
+        return response()->json([
+            'meta' => [
+                'code' => $exception->status,
+                'message' => 'Validation Error',
+            ],
+            'errors' => $this->camelKeys($exception->errors()),
+        ], $exception->status);
+    }
+
+    private function camelKeys(array $data): array
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            $key = Str::camel($key);
+            if (is_array($value)) {
+                $value = $this->camelKeys($value);
+            }
+            $result[$key] = $value;
+        }
+
+        return $result;
     }
 }

--- a/app/Http/Controllers/Api/InsightApiController.php
+++ b/app/Http/Controllers/Api/InsightApiController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Str;
 
 class InsightApiController extends Controller
 {
@@ -19,16 +18,4 @@ class InsightApiController extends Controller
         return $this->response($this->camelKeys($data), 'Success');
     }
 
-    private function camelKeys(array $data): array
-    {
-        $result = [];
-        foreach ($data as $key => $value) {
-            $key = Str::camel($key);
-            if (is_array($value)) {
-                $value = $this->camelKeys($value);
-            }
-            $result[$key] = $value;
-        }
-        return $result;
-    }
 }

--- a/app/Http/Controllers/Api/MadrasahApiController.php
+++ b/app/Http/Controllers/Api/MadrasahApiController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\Madrasah;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 
 class MadrasahApiController extends Controller
 {
@@ -88,16 +87,4 @@ class MadrasahApiController extends Controller
         return $this->response(null, 'Deleted');
     }
 
-    private function camelKeys(array $data): array
-    {
-        $result = [];
-        foreach ($data as $key => $value) {
-            $key = Str::camel($key);
-            if (is_array($value)) {
-                $value = $this->camelKeys($value);
-            }
-            $result[$key] = $value;
-        }
-        return $result;
-    }
 }

--- a/app/Http/Controllers/Api/MenuApiController.php
+++ b/app/Http/Controllers/Api/MenuApiController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\Menu;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 
 class MenuApiController extends Controller
 {
@@ -61,16 +60,4 @@ class MenuApiController extends Controller
         return $this->response($array, 'Created', 201);
     }
 
-    private function camelKeys(array $data): array
-    {
-        $result = [];
-        foreach ($data as $key => $value) {
-            $key = Str::camel($key);
-            if (is_array($value)) {
-                $value = $this->camelKeys($value);
-            }
-            $result[$key] = $value;
-        }
-        return $result;
-    }
 }

--- a/app/Http/Controllers/Api/RoleApiController.php
+++ b/app/Http/Controllers/Api/RoleApiController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\Role;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 
 class RoleApiController extends Controller
 {
@@ -47,16 +46,4 @@ class RoleApiController extends Controller
         return $this->response($array, 'Created', 201);
     }
 
-    private function camelKeys(array $data): array
-    {
-        $result = [];
-        foreach ($data as $key => $value) {
-            $key = Str::camel($key);
-            if (is_array($value)) {
-                $value = $this->camelKeys($value);
-            }
-            $result[$key] = $value;
-        }
-        return $result;
-    }
 }

--- a/app/Http/Controllers/Api/UserApiController.php
+++ b/app/Http/Controllers/Api/UserApiController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 
 class UserApiController extends Controller
 {
@@ -55,16 +54,4 @@ class UserApiController extends Controller
         return $this->response($data, 'Retrieved successfully');
     }
 
-    private function camelKeys(array $data): array
-    {
-        $result = [];
-        foreach ($data as $key => $value) {
-            $key = Str::camel($key);
-            if (is_array($value)) {
-                $value = $this->camelKeys($value);
-            }
-            $result[$key] = $value;
-        }
-        return $result;
-    }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Str;
 
 abstract class Controller
 {
@@ -21,5 +22,33 @@ abstract class Controller
             ],
             'result' => $result,
         ], $code);
+    }
+
+    protected function camelKeys(array $data): array
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            $key = Str::camel($key);
+            if (is_array($value)) {
+                $value = $this->camelKeys($value);
+            }
+            $result[$key] = $value;
+        }
+
+        return $result;
+    }
+
+    protected function snakeKeys(array $data): array
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            $key = Str::snake($key);
+            if (is_array($value)) {
+                $value = $this->snakeKeys($value);
+            }
+            $result[$key] = $value;
+        }
+
+        return $result;
     }
 }

--- a/app/Http/Middleware/ConvertCamelCase.php
+++ b/app/Http/Middleware/ConvertCamelCase.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class ConvertCamelCase
+{
+    public function handle(Request $request, Closure $next)
+    {
+        if ($request->isJson()) {
+            $request->replace($this->snakeKeys($request->all()));
+        }
+
+        return $next($request);
+    }
+
+    private function snakeKeys(array $data): array
+    {
+        $result = [];
+        foreach ($data as $key => $value) {
+            $key = Str::snake($key);
+            if (is_array($value)) {
+                $value = $this->snakeKeys($value);
+            }
+            $result[$key] = $value;
+        }
+        return $result;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -17,6 +17,7 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->append(App\Http\Middleware\ForceJsonResponse::class);
+        $middleware->append(App\Http\Middleware\ConvertCamelCase::class);
         $middleware->append(App\Http\Middleware\RouteLogger::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/tests/Feature/MadrasahApiTest.php
+++ b/tests/Feature/MadrasahApiTest.php
@@ -22,10 +22,10 @@ class MadrasahApiTest extends TestCase
                 'nsm' => '1234',
                 'name' => 'Madrasah Test',
                 'address' => 'Address',
-                'madrasah_level_id' => $level->id,
-                'regency_id' => 1,
-                'district_id' => 1,
-                'village_id' => 1,
+                'madrasahLevelId' => $level->id,
+                'regencyId' => 1,
+                'districtId' => 1,
+                'villageId' => 1,
             ]);
 
         $response->assertStatus(201)

--- a/tests/Feature/RegisterApiTest.php
+++ b/tests/Feature/RegisterApiTest.php
@@ -15,7 +15,7 @@ class RegisterApiTest extends TestCase
             'name' => 'John Doe',
             'email' => 'john@example.com',
             'password' => 'secret',
-            'password_confirmation' => 'secret',
+            'passwordConfirmation' => 'secret',
         ]);
 
         $response->assertStatus(201)

--- a/tests/Feature/ValidationErrorApiTest.php
+++ b/tests/Feature/ValidationErrorApiTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ValidationErrorApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_validation_error_format(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/v1/madrasahs', []);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('meta.message', 'Validation Error')
+            ->assertJsonStructure([
+                'meta' => ['code', 'message'],
+                'errors' => [
+                    'nsm',
+                    'name',
+                    'address',
+                    'madrasahLevelId',
+                    'regencyId',
+                    'districtId',
+                    'villageId',
+                ],
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- convert camelCase JSON request keys to snake case with new middleware
- centralize camelCase/snakeCase helpers in the base controller
- return validation errors in project format
- register new middleware
- update tests to use camelCase request bodies and add validation error test

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a47123dd0832f973dee6016b5b430