### PR TITLE
Add basic data seeders

### DIFF
--- a/database/seeders/AcademicYearSeeder.php
+++ b/database/seeders/AcademicYearSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\AcademicYear;
+
+class AcademicYearSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $startYear = 2024;
+        $endYear = 2050;
+
+        for ($year = $startYear; $year <= $endYear; $year++) {
+            $next = $year + 1;
+            AcademicYear::firstOrCreate(
+                ['code' => $year . '/' . $next],
+                [
+                    'start_date' => $year . '-07-01',
+                    'end_date' => $next . '-06-30',
+                ]
+            );
+        }
+    }
+}

--- a/database/seeders/ClassLevelSeeder.php
+++ b/database/seeders/ClassLevelSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\ClassLevel;
+use App\Models\MadrasahLevel;
+
+class ClassLevelSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $mi = MadrasahLevel::where('name', 'Madrasah Ibtidaiyah (MI)')->first();
+        $mts = MadrasahLevel::where('name', 'Madrasah Tsanawiyah (MTs)')->first();
+        $ma = MadrasahLevel::where('name', 'Madrasah Aliyah (MA)')->first();
+
+        if (!$mi || !$mts || !$ma) {
+            return;
+        }
+
+        $levels = [
+            $mi->id => ['I', 'II', 'III', 'IV', 'V', 'VI'],
+            $mts->id => ['VII', 'VIII', 'IX'],
+            $ma->id => ['X', 'XI', 'XII'],
+        ];
+
+        foreach ($levels as $madrasahId => $classes) {
+            foreach ($classes as $name) {
+                ClassLevel::firstOrCreate(
+                    ['name' => $name],
+                    ['madrasah_level_id' => $madrasahId]
+                );
+            }
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,10 @@ class DatabaseSeeder extends Seeder
             RoleSeeder::class,
             UserSeeder::class,
             MenuSeeder::class,
+            MadrasahLevelSeeder::class,
+            AcademicYearSeeder::class,
+            SubjectSeeder::class,
+            ClassLevelSeeder::class,
         ]);
     }
 }

--- a/database/seeders/MadrasahLevelSeeder.php
+++ b/database/seeders/MadrasahLevelSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\MadrasahLevel;
+
+class MadrasahLevelSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $levels = [
+            'Madrasah Ibtidaiyah (MI)',
+            'Madrasah Tsanawiyah (MTs)',
+            'Madrasah Aliyah (MA)',
+        ];
+
+        foreach ($levels as $level) {
+            MadrasahLevel::firstOrCreate(['name' => $level]);
+        }
+    }
+}

--- a/database/seeders/SubjectSeeder.php
+++ b/database/seeders/SubjectSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Subject;
+
+class SubjectSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $subjects = [
+            'Matematika',
+            'Bahasa Indonesia',
+            'Bahasa Inggris',
+            'Ilmu Pengetahuan Alam',
+            'Ilmu Pengetahuan Sosial',
+            'Pendidikan Agama Islam',
+        ];
+
+        foreach ($subjects as $subject) {
+            Subject::firstOrCreate(['name' => $subject]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- seed madrasah levels
- seed academic years up to 2050
- seed a list of default subjects
- seed class levels for each madrasah level
- register the new seeders in `DatabaseSeeder`

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a55b16580832fa2d8640957bc1d85