### PR TITLE
Add endpoints for academic and class data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,55 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# Ananlisis Kebutuhan Guru API
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+This repository contains a Laravel based REST API used for the teacher needs project. Authentication uses Sanctum and the API responses follow a common JSON structure.
 
-## About Laravel
+## Setup
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+```bash
+composer install
+cp .env.example .env
+php artisan key:generate
+php artisan migrate --seed
+```
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+## Available Endpoints
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+All routes are prefixed with `/api/v1` and protected using Sanctum (except `/login`).
 
-## Learning Laravel
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| POST   | `/login` | Obtain an auth token |
+| POST   | `/logout` | Revoke the auth token |
+| GET    | `/madrasahs` | List madrasahs |
+| POST   | `/madrasahs` | Create madrasah |
+| GET    | `/madrasahs/{id}` | Show madrasah |
+| PUT    | `/madrasahs/{id}` | Update madrasah |
+| DELETE | `/madrasahs/{id}` | Delete madrasah |
+| GET    | `/madrasah-levels` | List madrasah levels |
+| POST   | `/madrasah-levels` | Create madrasah level |
+| GET    | `/madrasah-levels/{id}` | Show madrasah level |
+| PUT    | `/madrasah-levels/{id}` | Update madrasah level |
+| DELETE | `/madrasah-levels/{id}` | Delete madrasah level |
+| GET    | `/class-levels` | List class levels (use `madrasahLevelId` query to filter) |
+| POST   | `/class-levels` | Create class level |
+| GET    | `/class-levels/{id}` | Show class level |
+| PUT    | `/class-levels/{id}` | Update class level |
+| DELETE | `/class-levels/{id}` | Delete class level |
+| GET    | `/subjects` | List subjects |
+| POST   | `/subjects` | Create subject |
+| GET    | `/subjects/{id}` | Show subject |
+| PUT    | `/subjects/{id}` | Update subject |
+| DELETE | `/subjects/{id}` | Delete subject |
+| GET    | `/academic-years` | List academic years |
+| POST   | `/academic-years` | Create academic year |
+| GET    | `/academic-years/{id}` | Show academic year |
+| PUT    | `/academic-years/{id}` | Update academic year |
+| DELETE | `/academic-years/{id}` | Delete academic year |
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+## Testing
 
-You may also try the [Laravel Bootcamp](https://bootcamp.laravel.com), where you will be guided through building a modern Laravel application from scratch.
+Run PHPUnit tests using:
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+```bash
+php artisan test
+```
 
-## Laravel Sponsors
-
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
-
-### Premium Partners
-
-- **[Vehikl](https://vehikl.com)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel)**
-- **[DevSquad](https://devsquad.com/hire-laravel-developers)**
-- **[Redberry](https://redberry.international/laravel-development)**
-- **[Active Logic](https://activelogic.com)**
-
-## Contributing
-
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
-
-## Code of Conduct
-
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
-
-## Security Vulnerabilities
-
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
-
-## License
-
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/app/Http/Controllers/Api/AcademicYearApiController.php
+++ b/app/Http/Controllers/Api/AcademicYearApiController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\AcademicYear;
+use Illuminate\Http\Request;
+
+class AcademicYearApiController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = $request->query('page', 1);
+        $pageSize = $request->query('pageSize', 10);
+        $years = AcademicYear::orderBy('id', 'asc')
+            ->paginate((int) $pageSize, ['*'], 'page', (int) $page);
+
+        $array = $this->camelKeys($years->toArray());
+        $customPagination = [
+            'currentPage' => $years->currentPage(),
+            'pageSize' => $years->perPage(),
+            'total' => $years->total(),
+            'data' => $array['data'] ?? [],
+        ];
+
+        return $this->response($customPagination, 'Data berhasil diambil');
+    }
+
+    public function show(int $id)
+    {
+        $year = AcademicYear::findOrFail($id);
+        $array = $this->camelKeys($year->toArray());
+
+        return $this->response($array, 'Data berhasil diambil');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'code' => ['required', 'string', 'unique:academic_years,code'],
+            'start_date' => ['required', 'date'],
+            'end_date' => ['required', 'date'],
+        ]);
+
+        $year = AcademicYear::create($data);
+        $array = $this->camelKeys($year->toArray());
+
+        return $this->response($array, 'Data berhasil disimpan', 201);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $year = AcademicYear::findOrFail($id);
+        $data = $request->validate([
+            'code' => ['string', 'unique:academic_years,code,' . $id],
+            'start_date' => ['date'],
+            'end_date' => ['date'],
+        ]);
+
+        $year->update($data);
+        $array = $this->camelKeys($year->toArray());
+
+        return $this->response($array, 'Data berhasil diperbarui');
+    }
+
+    public function destroy(int $id)
+    {
+        $year = AcademicYear::findOrFail($id);
+        $year->delete();
+
+        return $this->response(null, 'Data berhasil dihapus');
+    }
+}

--- a/app/Http/Controllers/Api/ClassLevelApiController.php
+++ b/app/Http/Controllers/Api/ClassLevelApiController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\ClassLevel;
+use Illuminate\Http\Request;
+
+class ClassLevelApiController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = $request->query('page', 1);
+        $pageSize = $request->query('pageSize', 10);
+        $madrasahLevelId = $request->query('madrasahLevelId');
+
+        $query = ClassLevel::query()->orderBy('id');
+        if ($madrasahLevelId) {
+            $query->where('madrasah_level_id', $madrasahLevelId);
+        }
+        $levels = $query->paginate((int) $pageSize, ['*'], 'page', (int) $page);
+
+        $array = $this->camelKeys($levels->toArray());
+        $customPagination = [
+            'currentPage' => $levels->currentPage(),
+            'pageSize' => $levels->perPage(),
+            'total' => $levels->total(),
+            'data' => $array['data'] ?? [],
+        ];
+
+        return $this->response($customPagination, 'Data berhasil diambil');
+    }
+
+    public function show(int $id)
+    {
+        $level = ClassLevel::findOrFail($id);
+        $array = $this->camelKeys($level->toArray());
+
+        return $this->response($array, 'Data berhasil diambil');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'unique:class_levels,name'],
+            'description' => ['string'],
+            'madrasah_level_id' => ['required', 'integer', 'exists:madrasah_levels,id'],
+        ]);
+
+        $level = ClassLevel::create($data);
+        $array = $this->camelKeys($level->toArray());
+
+        return $this->response($array, 'Data berhasil disimpan', 201);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $level = ClassLevel::findOrFail($id);
+        $data = $request->validate([
+            'name' => ['string', 'unique:class_levels,name,' . $id],
+            'description' => ['string'],
+            'madrasah_level_id' => ['integer', 'exists:madrasah_levels,id'],
+        ]);
+
+        $level->update($data);
+        $array = $this->camelKeys($level->toArray());
+
+        return $this->response($array, 'Data berhasil diperbarui');
+    }
+
+    public function destroy(int $id)
+    {
+        $level = ClassLevel::findOrFail($id);
+        $level->delete();
+
+        return $this->response(null, 'Data berhasil dihapus');
+    }
+}

--- a/app/Http/Controllers/Api/MadrasahLevelApiController.php
+++ b/app/Http/Controllers/Api/MadrasahLevelApiController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\MadrasahLevel;
+use Illuminate\Http\Request;
+
+class MadrasahLevelApiController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = $request->query('page', 1);
+        $pageSize = $request->query('pageSize', 10);
+        $levels = MadrasahLevel::orderBy('id', 'asc')
+            ->paginate((int) $pageSize, ['*'], 'page', (int) $page);
+
+        $array = $this->camelKeys($levels->toArray());
+        $customPagination = [
+            'currentPage' => $levels->currentPage(),
+            'pageSize' => $levels->perPage(),
+            'total' => $levels->total(),
+            'data' => $array['data'] ?? [],
+        ];
+
+        return $this->response($customPagination, 'Data berhasil diambil');
+    }
+
+    public function show(int $id)
+    {
+        $level = MadrasahLevel::findOrFail($id);
+        $array = $this->camelKeys($level->toArray());
+
+        return $this->response($array, 'Data berhasil diambil');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'unique:madrasah_levels,name'],
+            'description' => ['string'],
+        ]);
+
+        $level = MadrasahLevel::create($data);
+        $array = $this->camelKeys($level->toArray());
+
+        return $this->response($array, 'Data berhasil disimpan', 201);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $level = MadrasahLevel::findOrFail($id);
+        $data = $request->validate([
+            'name' => ['string', 'unique:madrasah_levels,name,' . $id],
+            'description' => ['string'],
+        ]);
+
+        $level->update($data);
+        $array = $this->camelKeys($level->toArray());
+
+        return $this->response($array, 'Data berhasil diperbarui');
+    }
+
+    public function destroy(int $id)
+    {
+        $level = MadrasahLevel::findOrFail($id);
+        $level->delete();
+
+        return $this->response(null, 'Data berhasil dihapus');
+    }
+}

--- a/app/Http/Controllers/Api/SubjectApiController.php
+++ b/app/Http/Controllers/Api/SubjectApiController.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Subject;
+use Illuminate\Http\Request;
+
+class SubjectApiController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = $request->query('page', 1);
+        $pageSize = $request->query('pageSize', 10);
+        $subjects = Subject::orderBy('id', 'asc')
+            ->paginate((int) $pageSize, ['*'], 'page', (int) $page);
+
+        $array = $this->camelKeys($subjects->toArray());
+        $customPagination = [
+            'currentPage' => $subjects->currentPage(),
+            'pageSize' => $subjects->perPage(),
+            'total' => $subjects->total(),
+            'data' => $array['data'] ?? [],
+        ];
+
+        return $this->response($customPagination, 'Data berhasil diambil');
+    }
+
+    public function show(int $id)
+    {
+        $subject = Subject::findOrFail($id);
+        $array = $this->camelKeys($subject->toArray());
+
+        return $this->response($array, 'Data berhasil diambil');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'unique:subjects,name'],
+        ]);
+
+        $subject = Subject::create($data);
+        $array = $this->camelKeys($subject->toArray());
+
+        return $this->response($array, 'Data berhasil disimpan', 201);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $subject = Subject::findOrFail($id);
+        $data = $request->validate([
+            'name' => ['string', 'unique:subjects,name,' . $id],
+        ]);
+
+        $subject->update($data);
+        $array = $this->camelKeys($subject->toArray());
+
+        return $this->response($array, 'Data berhasil diperbarui');
+    }
+
+    public function destroy(int $id)
+    {
+        $subject = Subject::findOrFail($id);
+        $subject->delete();
+
+        return $this->response(null, 'Data berhasil dihapus');
+    }
+}

--- a/database/factories/AcademicYearFactory.php
+++ b/database/factories/AcademicYearFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\AcademicYear>
+ */
+class AcademicYearFactory extends Factory
+{
+    protected $model = \App\Models\AcademicYear::class;
+
+    public function definition(): array
+    {
+        $start = $this->faker->dateTimeBetween('-2 years', 'now');
+        $end = (clone $start)->modify('+6 months');
+        return [
+            'code' => $start->format('Y') . '/' . $end->format('Y'),
+            'start_date' => $start->format('Y-m-d'),
+            'end_date' => $end->format('Y-m-d'),
+        ];
+    }
+}

--- a/database/factories/ClassLevelFactory.php
+++ b/database/factories/ClassLevelFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\ClassLevel>
+ */
+class ClassLevelFactory extends Factory
+{
+    protected $model = \App\Models\ClassLevel::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->word(),
+            'description' => $this->faker->sentence(),
+            'madrasah_level_id' => \App\Models\MadrasahLevel::factory(),
+        ];
+    }
+}

--- a/database/factories/SubjectFactory.php
+++ b/database/factories/SubjectFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Subject>
+ */
+class SubjectFactory extends Factory
+{
+    protected $model = \App\Models\Subject::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->word(),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,10 @@ use App\Http\Controllers\Api\MenuApiController;
 use App\Http\Controllers\Api\RoleApiController;
 use App\Http\Controllers\Api\InsightApiController;
 use App\Http\Controllers\Api\MadrasahApiController;
+use App\Http\Controllers\Api\MadrasahLevelApiController;
+use App\Http\Controllers\Api\ClassLevelApiController;
+use App\Http\Controllers\Api\SubjectApiController;
+use App\Http\Controllers\Api\AcademicYearApiController;
 
 Route::prefix('v1')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -36,5 +40,29 @@ Route::prefix('v1')->group(function () {
         Route::get('/madrasahs/{id}', [MadrasahApiController::class, 'show']);
         Route::put('/madrasahs/{id}', [MadrasahApiController::class, 'update']);
         Route::delete('/madrasahs/{id}', [MadrasahApiController::class, 'destroy']);
+
+        Route::get('/madrasah-levels', [MadrasahLevelApiController::class, 'index']);
+        Route::post('/madrasah-levels', [MadrasahLevelApiController::class, 'store']);
+        Route::get('/madrasah-levels/{id}', [MadrasahLevelApiController::class, 'show']);
+        Route::put('/madrasah-levels/{id}', [MadrasahLevelApiController::class, 'update']);
+        Route::delete('/madrasah-levels/{id}', [MadrasahLevelApiController::class, 'destroy']);
+
+        Route::get('/class-levels', [ClassLevelApiController::class, 'index']);
+        Route::post('/class-levels', [ClassLevelApiController::class, 'store']);
+        Route::get('/class-levels/{id}', [ClassLevelApiController::class, 'show']);
+        Route::put('/class-levels/{id}', [ClassLevelApiController::class, 'update']);
+        Route::delete('/class-levels/{id}', [ClassLevelApiController::class, 'destroy']);
+
+        Route::get('/subjects', [SubjectApiController::class, 'index']);
+        Route::post('/subjects', [SubjectApiController::class, 'store']);
+        Route::get('/subjects/{id}', [SubjectApiController::class, 'show']);
+        Route::put('/subjects/{id}', [SubjectApiController::class, 'update']);
+        Route::delete('/subjects/{id}', [SubjectApiController::class, 'destroy']);
+
+        Route::get('/academic-years', [AcademicYearApiController::class, 'index']);
+        Route::post('/academic-years', [AcademicYearApiController::class, 'store']);
+        Route::get('/academic-years/{id}', [AcademicYearApiController::class, 'show']);
+        Route::put('/academic-years/{id}', [AcademicYearApiController::class, 'update']);
+        Route::delete('/academic-years/{id}', [AcademicYearApiController::class, 'destroy']);
     });
 });

--- a/tests/Feature/AcademicYearApiTest.php
+++ b/tests/Feature/AcademicYearApiTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AcademicYearApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crud_academic_year(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/v1/academic-years', [
+                'code' => '2024/2025',
+                'startDate' => '2024-07-01',
+                'endDate' => '2025-06-30',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('result.code', '2024/2025');
+
+        $id = $response->json('result.id');
+
+        $update = $this->actingAs($user)
+            ->putJson('/api/v1/academic-years/' . $id, [
+                'code' => '2025/2026',
+            ]);
+
+        $update->assertStatus(200)
+            ->assertJsonPath('result.code', '2025/2026');
+
+        $delete = $this->actingAs($user)
+            ->deleteJson('/api/v1/academic-years/' . $id);
+
+        $delete->assertStatus(200)
+            ->assertJsonPath('meta.message', 'Data berhasil dihapus');
+    }
+}

--- a/tests/Feature/ClassLevelApiTest.php
+++ b/tests/Feature/ClassLevelApiTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ClassLevel;
+use App\Models\MadrasahLevel;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ClassLevelApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crud_class_level(): void
+    {
+        $level = MadrasahLevel::factory()->create();
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/v1/class-levels', [
+                'name' => 'I',
+                'description' => 'desc',
+                'madrasahLevelId' => $level->id,
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('result.name', 'I');
+
+        $id = $response->json('result.id');
+
+        $update = $this->actingAs($user)
+            ->putJson('/api/v1/class-levels/' . $id, [
+                'name' => 'Updated',
+            ]);
+
+        $update->assertStatus(200)
+            ->assertJsonPath('result.name', 'Updated');
+
+        $delete = $this->actingAs($user)
+            ->deleteJson('/api/v1/class-levels/' . $id);
+
+        $delete->assertStatus(200)
+            ->assertJsonPath('meta.message', 'Data berhasil dihapus');
+    }
+}

--- a/tests/Feature/MadrasahLevelApiTest.php
+++ b/tests/Feature/MadrasahLevelApiTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\MadrasahLevel;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MadrasahLevelApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crud_madrasah_level(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/v1/madrasah-levels', [
+                'name' => 'MI',
+                'description' => 'desc',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('result.name', 'MI');
+
+        $id = $response->json('result.id');
+
+        $update = $this->actingAs($user)
+            ->putJson('/api/v1/madrasah-levels/' . $id, [
+                'name' => 'Updated',
+            ]);
+
+        $update->assertStatus(200)
+            ->assertJsonPath('result.name', 'Updated');
+
+        $delete = $this->actingAs($user)
+            ->deleteJson('/api/v1/madrasah-levels/' . $id);
+
+        $delete->assertStatus(200)
+            ->assertJsonPath('meta.message', 'Data berhasil dihapus');
+    }
+}

--- a/tests/Feature/SubjectApiTest.php
+++ b/tests/Feature/SubjectApiTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SubjectApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_crud_subject(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)
+            ->postJson('/api/v1/subjects', [
+                'name' => 'Math',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('result.name', 'Math');
+
+        $id = $response->json('result.id');
+
+        $update = $this->actingAs($user)
+            ->putJson('/api/v1/subjects/' . $id, [
+                'name' => 'Updated',
+            ]);
+
+        $update->assertStatus(200)
+            ->assertJsonPath('result.name', 'Updated');
+
+        $delete = $this->actingAs($user)
+            ->deleteJson('/api/v1/subjects/' . $id);
+
+        $delete->assertStatus(200)
+            ->assertJsonPath('meta.message', 'Data berhasil dihapus');
+    }
+}


### PR DESCRIPTION
## Summary
- add controllers for madrasah levels, class levels, subjects and academic years
- create factories for the new models
- expose new API routes
- add feature tests
- update project README with available routes

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a5e398dbc832f9c0a880cf13e99c3