### PR TITLE
Add regency, district and village tables

### DIFF
--- a/app/Models/District.php
+++ b/app/Models/District.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class District extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'regency_id',
+        'name',
+        'created_by',
+        'updated_by',
+    ];
+
+    public function regency()
+    {
+        return $this->belongsTo(Regency::class);
+    }
+
+    public function villages()
+    {
+        return $this->hasMany(Village::class);
+    }
+}

--- a/app/Models/Regency.php
+++ b/app/Models/Regency.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Regency extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'created_by',
+        'updated_by',
+    ];
+
+    public function districts()
+    {
+        return $this->hasMany(District::class);
+    }
+}

--- a/app/Models/Village.php
+++ b/app/Models/Village.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Village extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'district_id',
+        'name',
+        'created_by',
+        'updated_by',
+    ];
+
+    public function district()
+    {
+        return $this->belongsTo(District::class);
+    }
+}

--- a/database/factories/DistrictFactory.php
+++ b/database/factories/DistrictFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class DistrictFactory extends Factory
+{
+    protected $model = \App\Models\District::class;
+
+    public function definition(): array
+    {
+        return [
+            'regency_id' => \App\Models\Regency::factory(),
+            'name' => $this->faker->citySuffix(),
+        ];
+    }
+}

--- a/database/factories/RegencyFactory.php
+++ b/database/factories/RegencyFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class RegencyFactory extends Factory
+{
+    protected $model = \App\Models\Regency::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->city(),
+        ];
+    }
+}

--- a/database/factories/VillageFactory.php
+++ b/database/factories/VillageFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class VillageFactory extends Factory
+{
+    protected $model = \App\Models\Village::class;
+
+    public function definition(): array
+    {
+        return [
+            'district_id' => \App\Models\District::factory(),
+            'name' => $this->faker->streetName(),
+        ];
+    }
+}

--- a/database/migrations/2025_06_24_100900_create_regencies_table.php
+++ b/database/migrations/2025_06_24_100900_create_regencies_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('regencies', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100);
+            $table->timestamp('created_at')->default(now());
+            $table->string('created_by', 100)->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->string('updated_by', 100)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('regencies');
+    }
+};

--- a/database/migrations/2025_06_24_101000_create_districts_table.php
+++ b/database/migrations/2025_06_24_101000_create_districts_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('districts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('regency_id')->constrained('regencies');
+            $table->string('name', 100);
+            $table->timestamp('created_at')->default(now());
+            $table->string('created_by', 100)->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->string('updated_by', 100)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('districts');
+    }
+};

--- a/database/migrations/2025_06_24_101100_create_villages_table.php
+++ b/database/migrations/2025_06_24_101100_create_villages_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('villages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('district_id')->constrained('districts');
+            $table->string('name', 100);
+            $table->timestamp('created_at')->default(now());
+            $table->string('created_by', 100)->nullable();
+            $table->timestamp('updated_at')->nullable();
+            $table->string('updated_by', 100)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('villages');
+    }
+};


### PR DESCRIPTION
## Summary
- create migrations for regencies, districts, and villages
- add corresponding models and factories

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: no such file or directory)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb8eb3e80832f9a224a8bcdabc396