### PR TITLE
Improve logging with requestId

### DIFF
--- a/app/Http/Middleware/RouteLogger.php
+++ b/app/Http/Middleware/RouteLogger.php
@@ -4,22 +4,38 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 class RouteLogger
 {
     public function handle($request, Closure $next)
     {
+        $requestId = $request->header('X-Request-Id', (string) Str::uuid());
+        $request->headers->set('X-Request-Id', $requestId);
+
         $response = $next($request);
+        $response->headers->set('X-Request-Id', $requestId);
 
         Log::channel('route')->info('route_access', [
-            'time'   => now()->toDateTimeString(),
-            'ip'     => $request->ip(),
-            'method' => $request->method(),
-            'uri'    => $request->path(),
-            'status' => $response->status(),
-            'user'   => optional($request->user())->id,
+            'requestId' => $requestId,
+            'time'      => now()->toDateTimeString(),
+            'ip'        => $request->ip(),
+            'method'    => $request->method(),
+            'uri'       => $request->path(),
+            'status'    => $response->status(),
+            'user'      => optional($request->user())->id,
+            'request'   => $request->all(),
+            'response'  => $this->parseResponse($response),
         ]);
 
         return $response;
+    }
+
+    private function parseResponse($response)
+    {
+        $content = $response->getContent();
+        $json = json_decode($content, true);
+
+        return $json ?? $content;
     }
 }


### PR DESCRIPTION
## Summary
- include requestId and full request/response data in the RouteLogger middleware

## Testing
- `composer install` *(fails: composer not found)*
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685ca50d03ac832fa9b84f3faca6ac63