### PR TITLE
Add lat/long fields to location tables

### DIFF
--- a/app/Models/District.php
+++ b/app/Models/District.php
@@ -12,6 +12,8 @@ class District extends Model
     protected $fillable = [
         'regency_id',
         'name',
+        'latitude',
+        'longitude',
         'created_by',
         'updated_by',
     ];

--- a/app/Models/Regency.php
+++ b/app/Models/Regency.php
@@ -11,6 +11,8 @@ class Regency extends Model
 
     protected $fillable = [
         'name',
+        'latitude',
+        'longitude',
         'created_by',
         'updated_by',
     ];

--- a/app/Models/Village.php
+++ b/app/Models/Village.php
@@ -12,6 +12,8 @@ class Village extends Model
     protected $fillable = [
         'district_id',
         'name',
+        'latitude',
+        'longitude',
         'created_by',
         'updated_by',
     ];

--- a/database/factories/DistrictFactory.php
+++ b/database/factories/DistrictFactory.php
@@ -13,6 +13,8 @@ class DistrictFactory extends Factory
         return [
             'regency_id' => \App\Models\Regency::factory(),
             'name' => $this->faker->citySuffix(),
+            'latitude' => $this->faker->latitude(),
+            'longitude' => $this->faker->longitude(),
         ];
     }
 }

--- a/database/factories/RegencyFactory.php
+++ b/database/factories/RegencyFactory.php
@@ -12,6 +12,8 @@ class RegencyFactory extends Factory
     {
         return [
             'name' => $this->faker->city(),
+            'latitude' => $this->faker->latitude(),
+            'longitude' => $this->faker->longitude(),
         ];
     }
 }

--- a/database/factories/VillageFactory.php
+++ b/database/factories/VillageFactory.php
@@ -13,6 +13,8 @@ class VillageFactory extends Factory
         return [
             'district_id' => \App\Models\District::factory(),
             'name' => $this->faker->streetName(),
+            'latitude' => $this->faker->latitude(),
+            'longitude' => $this->faker->longitude(),
         ];
     }
 }

--- a/database/migrations/2025_06_24_100900_create_regencies_table.php
+++ b/database/migrations/2025_06_24_100900_create_regencies_table.php
@@ -11,6 +11,8 @@ return new class extends Migration
         Schema::create('regencies', function (Blueprint $table) {
             $table->id();
             $table->string('name', 100);
+            $table->decimal('latitude', 10, 8)->nullable();
+            $table->decimal('longitude', 11, 8)->nullable();
             $table->timestamp('created_at')->default(now());
             $table->string('created_by', 100)->nullable();
             $table->timestamp('updated_at')->nullable();

--- a/database/migrations/2025_06_24_101000_create_districts_table.php
+++ b/database/migrations/2025_06_24_101000_create_districts_table.php
@@ -12,6 +12,8 @@ return new class extends Migration
             $table->id();
             $table->foreignId('regency_id')->constrained('regencies');
             $table->string('name', 100);
+            $table->decimal('latitude', 10, 8)->nullable();
+            $table->decimal('longitude', 11, 8)->nullable();
             $table->timestamp('created_at')->default(now());
             $table->string('created_by', 100)->nullable();
             $table->timestamp('updated_at')->nullable();

--- a/database/migrations/2025_06_24_101100_create_villages_table.php
+++ b/database/migrations/2025_06_24_101100_create_villages_table.php
@@ -12,6 +12,8 @@ return new class extends Migration
             $table->id();
             $table->foreignId('district_id')->constrained('districts');
             $table->string('name', 100);
+            $table->decimal('latitude', 10, 8)->nullable();
+            $table->decimal('longitude', 11, 8)->nullable();
             $table->timestamp('created_at')->default(now());
             $table->string('created_by', 100)->nullable();
             $table->timestamp('updated_at')->nullable();


### PR DESCRIPTION
## Summary
- add `latitude` and `longitude` fields to regencies, districts, and villages
- include lat/long in fillable model attributes
- update factories to generate coordinates

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ccad66bf0832f9383d593fe941310