### PR TITLE
Add API for regency, district and village

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ All routes are prefixed with `/api/v1` and protected using Sanctum (except `/log
 | GET    | `/subjects/{id}` | Show subject |
 | PUT    | `/subjects/{id}` | Update subject |
 | DELETE | `/subjects/{id}` | Delete subject |
+| GET    | `/regencies` | List regencies |
+| GET    | `/districts` | List districts (use `regencyId` query to filter) |
+| GET    | `/villages` | List villages (use `districtId` query to filter) |
 | GET    | `/academic-years` | List academic years |
 | POST   | `/academic-years` | Create academic year |
 | GET    | `/academic-years/{id}` | Show academic year |

--- a/app/Http/Controllers/Api/DistrictApiController.php
+++ b/app/Http/Controllers/Api/DistrictApiController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\District;
+use Illuminate\Http\Request;
+
+class DistrictApiController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = $request->query('page', 1);
+        $pageSize = $request->query('pageSize', 10);
+        $regencyId = $request->query('regencyId');
+
+        $query = District::query()->orderBy('id', 'asc');
+
+        if ($regencyId) {
+            $query->where('regency_id', $regencyId);
+        }
+
+        $districts = $query->paginate((int) $pageSize, ['*'], 'page', (int) $page);
+
+        $array = $this->camelKeys($districts->toArray());
+        $customPagination = [
+            'currentPage' => $districts->currentPage(),
+            'pageSize' => $districts->perPage(),
+            'total' => $districts->total(),
+            'result' => $array['data'] ?? [],
+        ];
+
+        return $this->response($customPagination, 'Data berhasil diambil');
+    }
+}

--- a/app/Http/Controllers/Api/RegencyApiController.php
+++ b/app/Http/Controllers/Api/RegencyApiController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Regency;
+use Illuminate\Http\Request;
+
+class RegencyApiController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = $request->query('page', 1);
+        $pageSize = $request->query('pageSize', 10);
+
+        $regencies = Regency::orderBy('id', 'asc')
+            ->paginate((int) $pageSize, ['*'], 'page', (int) $page);
+
+        $array = $this->camelKeys($regencies->toArray());
+        $customPagination = [
+            'currentPage' => $regencies->currentPage(),
+            'pageSize' => $regencies->perPage(),
+            'total' => $regencies->total(),
+            'result' => $array['data'] ?? [],
+        ];
+
+        return $this->response($customPagination, 'Data berhasil diambil');
+    }
+}

--- a/app/Http/Controllers/Api/VillageApiController.php
+++ b/app/Http/Controllers/Api/VillageApiController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Village;
+use Illuminate\Http\Request;
+
+class VillageApiController extends Controller
+{
+    public function index(Request $request)
+    {
+        $page = $request->query('page', 1);
+        $pageSize = $request->query('pageSize', 10);
+        $districtId = $request->query('districtId');
+
+        $query = Village::query()->orderBy('id', 'asc');
+
+        if ($districtId) {
+            $query->where('district_id', $districtId);
+        }
+
+        $villages = $query->paginate((int) $pageSize, ['*'], 'page', (int) $page);
+
+        $array = $this->camelKeys($villages->toArray());
+        $customPagination = [
+            'currentPage' => $villages->currentPage(),
+            'pageSize' => $villages->perPage(),
+            'total' => $villages->total(),
+            'result' => $array['data'] ?? [],
+        ];
+
+        return $this->response($customPagination, 'Data berhasil diambil');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -11,6 +11,9 @@ use App\Http\Controllers\Api\MadrasahLevelApiController;
 use App\Http\Controllers\Api\ClassLevelApiController;
 use App\Http\Controllers\Api\SubjectApiController;
 use App\Http\Controllers\Api\AcademicYearApiController;
+use App\Http\Controllers\Api\RegencyApiController;
+use App\Http\Controllers\Api\DistrictApiController;
+use App\Http\Controllers\Api\VillageApiController;
 
 Route::prefix('v1')->group(function () {
     Route::post('/login', [AuthController::class, 'login']);
@@ -57,6 +60,10 @@ Route::prefix('v1')->group(function () {
         Route::get('/subjects/{id}', [SubjectApiController::class, 'show']);
         Route::put('/subjects/{id}', [SubjectApiController::class, 'update']);
         Route::delete('/subjects/{id}', [SubjectApiController::class, 'destroy']);
+
+        Route::get('/regencies', [RegencyApiController::class, 'index']);
+        Route::get('/districts', [DistrictApiController::class, 'index']);
+        Route::get('/villages', [VillageApiController::class, 'index']);
 
         Route::get('/academic-years', [AcademicYearApiController::class, 'index']);
         Route::post('/academic-years', [AcademicYearApiController::class, 'store']);

--- a/tests/Feature/LocationApiTest.php
+++ b/tests/Feature/LocationApiTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\District;
+use App\Models\Regency;
+use App\Models\User;
+use App\Models\Village;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LocationApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_lists_regencies(): void
+    {
+        Regency::factory()->count(3)->create();
+
+        $response = $this->actingAs(User::factory()->create())
+            ->getJson('/api/v1/regencies');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'meta' => ['code', 'message'],
+                'data' => ['currentPage', 'result'],
+            ]);
+    }
+
+    public function test_filter_districts_by_regency_id(): void
+    {
+        $regency = Regency::factory()->create();
+        $district = District::factory()->create(['regency_id' => $regency->id]);
+        District::factory()->create();
+
+        $response = $this->actingAs(User::factory()->create())
+            ->getJson('/api/v1/districts?regencyId=' . $regency->id);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('result.total', 1)
+            ->assertJsonPath('result.result.0.id', $district->id);
+    }
+
+    public function test_filter_villages_by_district_id(): void
+    {
+        $district = District::factory()->create();
+        $village = Village::factory()->create(['district_id' => $district->id]);
+        Village::factory()->create();
+
+        $response = $this->actingAs(User::factory()->create())
+            ->getJson('/api/v1/villages?districtId=' . $district->id);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('result.total', 1)
+            ->assertJsonPath('result.result.0.id', $village->id);
+    }
+}


### PR DESCRIPTION
## Summary
- add RegencyApiController, DistrictApiController and VillageApiController
- expose routes `/regencies`, `/districts`, `/villages`
- document new endpoints in README
- add LocationApiTest

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d0081be2c832fb1032f1f9836b6ab